### PR TITLE
Use ubuntu 16.04 as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 RUN \ 
   apt-get update && \


### PR DESCRIPTION
We need it because ubuntu 14:04 supports only Python 2.7.6 and [ansible-vault lookup plugin](https://github.com/jhaals/ansible-vault)  requires at least 2.7.9.